### PR TITLE
Fix clipped messages

### DIFF
--- a/qml/components/TextMessage.qml
+++ b/qml/components/TextMessage.qml
@@ -27,4 +27,5 @@ Label {
         rightMargin: Theme.paddingMedium
     }
     wrapMode: Text.WordWrap
+    height: contentHeight + Theme.paddingMedium
 }


### PR DESCRIPTION
1. **Explanation**: 
    - Force the message label's height to be more than its content height.

2. **Fixed issues**: 
    - Fixed #201

3. **Testing environment**: 
    - Sailfish OS version: 3.0.1.14
    - Sailfish OS hardware: Xperia XA2 Plus

This is not an ideal solution because of two problems:

- Sometimes message text overlaps with the timestamp despite padding
- It generates many `QML Label: Binding loop detected for property "height"` messages, but I don't know if this is a serious problem

but at least the full message text should always be visible :)
