### PR TITLE
Preserve aspect ratio of photos

### DIFF
--- a/qml/components/Avatar.qml
+++ b/qml/components/Avatar.qml
@@ -25,6 +25,7 @@ Image {
     id: image
     width: Theme.itemSizeLarge
     height: width
+    fillMode: Image.PreserveAspectCrop
     onStatusChanged: {
         if(status == Image.Error) {
             console.warn("Can't load image")

--- a/qml/components/MatchesCover.qml
+++ b/qml/components/MatchesCover.qml
@@ -48,6 +48,7 @@ Item {
                 id: image
                 width: Layout.columnSpan*parent.width/parent.columns
                 height: Layout.rowSpan*parent.width/parent.columns
+                fillMode: Image.PreserveAspectCrop
                 Layout.minimumWidth: width
                 Layout.minimumHeight: height
                 Layout.preferredWidth: width

--- a/qml/components/PhotoGridLayout.qml
+++ b/qml/components/PhotoGridLayout.qml
@@ -66,6 +66,7 @@ Item {
                     id: image
                     width: parent.width
                     height: parent.height
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: width
                     sourceSize.height: height
                     source: {
@@ -159,6 +160,7 @@ Item {
         id: fullScreen
         width: parent.width
         height: parent.width
+        fillMode: Image.PreserveAspectCrop
         anchors.centerIn: parent
         visible: false
         asynchronous: true

--- a/qml/components/PhotoGridLayout.qml
+++ b/qml/components/PhotoGridLayout.qml
@@ -29,8 +29,15 @@ Item {
     width: parent.width
     height: parent.width
 
+    function openFullScreen(imageSource) {
+        fullScreen.source = imageSource
+        fullScreen.visible = true
+        layout.visible = false
+    }
+
     function closeFullScreen() {
         fullScreen.visible = false
+        layout.visible = true
     }
 
     GridLayout {
@@ -113,14 +120,12 @@ Item {
                         anchors.fill: parent
                         enabled: image.status == Image.Ready && repeater.count > 1
                         onClicked: {
-                            fullScreen.source = image.source
-                            fullScreen.visible = true
+                            openFullScreen(image.source)
                             _showRemoveButton = false
                         }
                         onPressAndHold: {
                             if(editable) {
-                                fullScreen.source = image.source
-                                fullScreen.visible = true
+                                openFullScreen(image.source)
                                 deleteOverlay.photoId = model.id
                                 _showRemoveButton = true
                             }
@@ -160,7 +165,7 @@ Item {
         id: fullScreen
         width: parent.width
         height: parent.width
-        fillMode: Image.PreserveAspectCrop
+        fillMode: Image.PreserveAspectFit
         anchors.centerIn: parent
         visible: false
         asynchronous: true
@@ -170,7 +175,7 @@ Item {
             id: touchFull
             anchors.fill: parent
             enabled: repeater.count > 1
-            onClicked: fullScreen.visible = false
+            onClicked: closeFullScreen()
         }
 
         Rectangle {
@@ -196,7 +201,7 @@ Item {
                                                            : Theme.primaryColor)
                 onClicked: {
                     _showRemoveButton = false
-                    fullScreen.visible = false
+                    closeFullScreen()
                     removed(deleteOverlay.photoId)
                 }
             }


### PR DESCRIPTION
This fixes that photos were stretched to a square if they weren't available on the server as squares by setting `fillMode: Image.PreserveAspectCrop` on the images.